### PR TITLE
Introduce MutationPointAddress

### DIFF
--- a/include/MutationEngine.h
+++ b/include/MutationEngine.h
@@ -11,7 +11,7 @@ class MutationPoint;
 /// FIXME: This class seems to be redundant
 class MutationEngine {
 public:
-  void applyMutation(MutationPoint &MP);
+  void applyMutation(llvm::Module *M, MutationPoint &MP);
   void revertMutation(MutationPoint &MP);
 };
 

--- a/include/MutationOperators/AddMutationOperator.h
+++ b/include/MutationOperators/AddMutationOperator.h
@@ -4,10 +4,12 @@
 
 namespace Mutang {
 
+class MutationPointAddress;
+
 class AddMutationOperator : public MutationOperator {
 public:
   bool canBeApplied(llvm::Value &V) override;
-  llvm::Value *applyMutation(llvm::Value &OriginalValue) override;
+  llvm::Value *applyMutation(llvm::Module *M, MutationPointAddress address, llvm::Value &OriginalValue) override;
   llvm::Value *revertMutation(llvm::Value &Value) override;
 };
 

--- a/include/MutationOperators/MutationOperator.h
+++ b/include/MutationOperators/MutationOperator.h
@@ -2,14 +2,17 @@
 
 namespace llvm {
   class Value;
+  class Module;
 }
 
 namespace Mutang {
 
+class MutationPointAddress;
+
 class MutationOperator {
 public:
   virtual bool canBeApplied(llvm::Value &V) = 0;
-  virtual llvm::Value *applyMutation(llvm::Value &OriginalValue) = 0;
+  virtual llvm::Value *applyMutation(llvm::Module *M, MutationPointAddress address, llvm::Value &OriginalValue) = 0;
   virtual llvm::Value *revertMutation(llvm::Value &Value) = 0;
   virtual ~MutationOperator() {}
 };

--- a/include/MutationPoint.h
+++ b/include/MutationPoint.h
@@ -3,28 +3,48 @@
 #include "llvm/ADT/ArrayRef.h"
 
 namespace llvm {
-class Value;
+  class Value;
+  class Module;
 }
 
 namespace Mutang {
 
 class MutationOperator;
 
+/// \brief Container class that stores information needed to find MutationPoints.
+/// We need the indexes of function, basic block and instruction to find the mutation point
+/// in the clone of original module, when mutation operator is to apply mutation in that clone.
+class MutationPointAddress {
+  int FnIndex;
+  int BBIndex;
+  int IIndex;
+
+public:
+  MutationPointAddress(int FnIndex, int BBIndex, int IIndex) :
+  FnIndex(FnIndex), BBIndex(BBIndex), IIndex(IIndex) {}
+
+  int getFnIndex() { return FnIndex; }
+  int getBBIndex() { return BBIndex; }
+  int getIIndex() { return IIndex; }
+};
+
 class MutationPoint {
   MutationOperator *MutOp;
+  MutationPointAddress Address;
   llvm::Value *OriginalValue;
   llvm::Value *MutatedValue;
 public:
-  MutationPoint(MutationOperator *MO, llvm::Value *Val);
+  MutationPoint(MutationOperator *MO, MutationPointAddress Address, llvm::Value *Val);
   ~MutationPoint();
 
   MutationOperator *getOperator();
 
+  MutationPointAddress getAddress();
   llvm::Value *getOriginalValue();
   llvm::Value *getMutatedValue();
 
-  void applyMutation();
+  void applyMutation(llvm::Module *M);
   void revertMutation();
 };
-  
+
 }

--- a/lib/Driver.cpp
+++ b/lib/Driver.cpp
@@ -74,10 +74,14 @@ std::vector<std::unique_ptr<TestResult>> Driver::Run() {
     for (auto Testee : TestFinder.findTestees(*Test)) {
       auto ObjectFiles = AllButOne(Testee->getParent());
       for (auto &MutationPoint : TestFinder.findMutationPoints(MutationOperators, *Testee)) {
-        MutationPoint->applyMutation();
+
+        /// TODO: here the clone of Testee->getParent() will be used very soon instead.
+        /// For now we are applying mutation to the module same as of mutation point.
+        MutationPoint->applyMutation(Testee->getParent());
 
         auto Mutant = Compiler.CompilerModule(Testee->getParent());
         ObjectFiles.push_back(Mutant.getBinary());
+
         /// Rollback mutation once we have compiled the module
         MutationPoint->revertMutation();
 

--- a/lib/MutationEngine.cpp
+++ b/lib/MutationEngine.cpp
@@ -10,8 +10,8 @@
 using namespace llvm;
 using namespace Mutang;
 
-void MutationEngine::applyMutation(MutationPoint &MP) {
-  MP.applyMutation();
+void MutationEngine::applyMutation(llvm::Module *M, MutationPoint &MP) {
+  MP.applyMutation(M);
 }
 
 void MutationEngine::revertMutation(MutationPoint &MP) {

--- a/lib/MutationOperators/AddMutationOperator.cpp
+++ b/lib/MutationOperators/AddMutationOperator.cpp
@@ -1,6 +1,12 @@
 #include "MutationOperators/AddMutationOperator.h"
 
+#include "MutationPoint.h"
+
+#include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+
+#include <iterator>
 
 using namespace llvm;
 using namespace Mutang;
@@ -15,10 +21,19 @@ bool AddMutationOperator::canBeApplied(Value &V) {
   return false;
 }
 
-llvm::Value *AddMutationOperator::applyMutation(Value &V) {
+llvm::Value *AddMutationOperator::applyMutation(Module *M, MutationPointAddress address, Value &V) {
+
+  /// In the following V argument is not used. Eventually it will be removed from
+  /// this method's signature because it will be not relevant
+  /// when mutations will be applied on copies of original module
+
+  llvm::Function &F = *(std::next(M->begin(), address.getFnIndex()));
+  llvm::BasicBlock &B = *(std::next(F.begin(), address.getBBIndex()));
+  llvm::Instruction &I = *(std::next(B.begin(), address.getIIndex()));
+
   /// TODO: Cover FAdd
   /// TODO: Take care of NUW/NSW
-  BinaryOperator *BinOp = cast<BinaryOperator>(&V);
+  BinaryOperator *BinOp = cast<BinaryOperator>(&I);
 
   assert(BinOp->getOpcode() == Instruction::Add);
 

--- a/lib/MutationPoint.cpp
+++ b/lib/MutationPoint.cpp
@@ -5,13 +5,17 @@
 using namespace llvm;
 using namespace Mutang;
 
-MutationPoint::MutationPoint(MutationOperator *MO, llvm::Value *Val) :
-  MutOp(MO), OriginalValue(Val), MutatedValue(nullptr) {}
+MutationPoint::MutationPoint(MutationOperator *MO, MutationPointAddress Address, llvm::Value *Val) :
+  MutOp(MO), Address(Address), OriginalValue(Val), MutatedValue(nullptr) {}
 
 MutationPoint::~MutationPoint() {}
 
 MutationOperator *MutationPoint::getOperator() {
   return MutOp;
+}
+
+MutationPointAddress MutationPoint::getAddress() {
+  return Address;
 }
 
 Value *MutationPoint::getOriginalValue() {
@@ -22,10 +26,10 @@ Value *MutationPoint::getMutatedValue() {
   return MutatedValue;
 }
 
-void MutationPoint::applyMutation() {
+void MutationPoint::applyMutation(llvm::Module *M) {
   assert(!MutatedValue && "Mutation already applied");
 
-  MutatedValue = MutOp->applyMutation(*OriginalValue);
+  MutatedValue = MutOp->applyMutation(M, Address, *OriginalValue);
 }
 
 void MutationPoint::revertMutation() {

--- a/unittests/MutationEngineTests.cpp
+++ b/unittests/MutationEngineTests.cpp
@@ -65,7 +65,7 @@ TEST(MutationEngine, applyMutation) {
 
   MutationEngine Engine;
 
-  Engine.applyMutation(*MP);
+  Engine.applyMutation(Testee->getParent(), *MP);
 
   // After mutation applied on instruction it should be erased
   Instruction *OldInstruction = cast<BinaryOperator>(MP->getOriginalValue());
@@ -118,7 +118,7 @@ TEST(MutationEngine, applyAndRevertMutation) {
 
   MutationEngine Engine;
 
-  Engine.applyMutation(*MP);
+  Engine.applyMutation(Testee->getParent(), *MP);
 
   // After mutation applied on instruction it should be erased
   Instruction *OldInstruction = cast<BinaryOperator>(MP->getOriginalValue());

--- a/unittests/SimpleTestFinderTest.cpp
+++ b/unittests/SimpleTestFinderTest.cpp
@@ -79,4 +79,9 @@ TEST(SimpleTestFinder, FindMutationPoints) {
   MutationPoint *MP = (*(MutationPoints.begin())).get();
   ASSERT_EQ(&MutOp, MP->getOperator());
   ASSERT_TRUE(isa<BinaryOperator>(MP->getOriginalValue()));
+
+  MutationPointAddress MPA = MP->getAddress();
+  ASSERT_TRUE(MPA.getFnIndex() == 0);
+  ASSERT_TRUE(MPA.getBBIndex() == 2);
+  ASSERT_TRUE(MPA.getIIndex() == 1);
 }

--- a/unittests/TestRunnersTests.cpp
+++ b/unittests/TestRunnersTests.cpp
@@ -76,7 +76,7 @@ TEST(SimpleTestRunner, runTest) {
 
   MutationPoint *MP = (*(MutationPoints.begin())).get();
   MutationEngine Engine;
-  Engine.applyMutation(*MP);
+  Engine.applyMutation(Testee->getParent(), *MP);
 
   {
     auto Obj = Compiler.CompilerModule(ModuleWithTests);
@@ -146,7 +146,7 @@ TEST(SimpleTestRunner, runTestUsingLibC) {
 
   MutationPoint *MP = (*(MutationPoints.begin())).get();
   MutationEngine Engine;
-  Engine.applyMutation(*MP);
+  Engine.applyMutation(Testee->getParent(), *MP);
 
   Obj = Compiler.CompilerModule(ModuleWithTests);
   ObjectFiles.push_back(Obj.getBinary());


### PR DESCRIPTION
MutationPointAddress is introduced to store address of MutationPoint to allow MutationOperator to find that mutation point in a clone of original module.

Mutation operator now applies mutation to a module, which is given to it as argument, using the MutationPointAddress to look up for mutation point.

Value `&V` argument in `AddMutationOperator::applyMutation` is not used, and is left as deprecated for removal when it is clear it will not be needed when "remote JIT" is in place.